### PR TITLE
chore(docker): add .dockerignore

### DIFF
--- a/project/backend/.dockerignore
+++ b/project/backend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+*.log
+coverage
+.git
+

--- a/project/frontend/.dockerignore
+++ b/project/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.env
+*.log
+coverage
+.git
+


### PR DESCRIPTION
## Summary
- Add `.dockerignore` for `project/backend` and `project/frontend` to keep images smaller and avoid copying local artifacts.

## Test plan
- [ ] `docker compose build`
- [ ] `docker compose up`